### PR TITLE
[DEV-9] Clean up tm script

### DIFF
--- a/.tasks/DEV/DEV-9.json
+++ b/.tasks/DEV/DEV-9.json
@@ -2,14 +2,29 @@
   "id": "DEV-9",
   "title": "Review tm script",
   "description": "Check pushd/popd usage and handle failures cleanly",
-  "status": "todo",
+  "status": "done",
   "comments": [
     {
       "id": 1,
       "text": "Update tm to ensure clean exit on errors and improve comments.",
       "created_at": 1748521738.6394048
+    },
+    {
+      "id": 2,
+      "text": "Started task and read AGENTS instructions.",
+      "created_at": 1748522073.6515613
+    },
+    {
+      "id": 3,
+      "text": "Implemented cleanup trap for pushd/popd in scripts.",
+      "created_at": 1748522148.013668
+    },
+    {
+      "id": 4,
+      "text": "Finished implementing improvements.",
+      "created_at": 1748522164.5088303
     }
   ],
   "created_at": 1748521737.6656857,
-  "updated_at": 1748521738.6394389
+  "updated_at": 1748522164.5088532
 }

--- a/init_venv
+++ b/init_venv
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+# Always restore working directory on exit
+cleanup() {
+    popd >/dev/null || true
+}
 
 pushd "$(dirname "$0")" >/dev/null
+trap cleanup EXIT
 
 if [ ! -d ".venv" ]; then
     python3 -m venv .venv
@@ -9,7 +15,8 @@ fi
 
 source .venv/bin/activate
 if [ -z "$TM_NO_INSTALL" ]; then
-    pip install -r requirements.txt || echo "pip install failed, continuing"
+    if ! pip install -r requirements.txt; then
+        echo "pip install failed, continuing"
+    fi
 fi
 
-popd >/dev/null

--- a/tm
+++ b/tm
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+# Ensure we return to the original directory even if a command fails
+cleanup() {
+    popd >/dev/null || true
+}
 
 pushd "$(dirname "$0")" >/dev/null
+trap cleanup EXIT
 
 ./init_venv >/dev/null
 source .venv/bin/activate
 python task-manager/task_manager.py "$@"
 
-popd >/dev/null


### PR DESCRIPTION
## What
- ensure both `tm` and `init_venv` return to the original directory
- use `set -euo pipefail` and traps for safer failure handling
- mark DEV-9 as complete

## Verification
- `pytest -q`
- `ruff check .`
- `mypy .`
