### PR TITLE
[DEV-14] Add React dashboard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Node build artifacts
+react-dashboard/node_modules/
+react-dashboard/out/

--- a/.tasks/DEV/DEV-14.json
+++ b/.tasks/DEV/DEV-14.json
@@ -2,14 +2,34 @@
   "id": "DEV-14",
   "title": "Create React dashboard frontend",
   "description": "Use Next.js to render tasks in kanban and table views",
-  "status": "todo",
+  "status": "done",
   "comments": [
     {
       "id": 1,
       "text": "Build React components for task table and kanban board",
       "created_at": 1748525155.4904478
+    },
+    {
+      "id": 2,
+      "text": "Starting development of React dashboard",
+      "created_at": 1748534801.3095376
+    },
+    {
+      "id": 3,
+      "text": "Added Next.js frontend skeleton with table and kanban views",
+      "created_at": 1748534898.9123201
+    },
+    {
+      "id": 4,
+      "text": "Updated gitignore and documentation",
+      "created_at": 1748534904.7484431
+    },
+    {
+      "id": 5,
+      "text": "Marked task complete",
+      "created_at": 1748534908.2287757
     }
   ],
   "created_at": 1748525154.3372107,
-  "updated_at": 1748525155.4904807
+  "updated_at": 1748534908.2288082
 }

--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ Generate an HTML dashboard listing all tasks:
 
 The page is written to `docs/index.html` and can be published with GitHub Pages.
 
+
+### React Dashboard
+A Next.js frontend under `react-dashboard/` renders tasks in both table and kanban views.
+To develop locally:
+```bash
+cd react-dashboard
+npm install
+npm run dev
+```
+Use `npm run build` to generate a static site in `out/` for GitHub Pages deployment.

--- a/react-dashboard/README.md
+++ b/react-dashboard/README.md
@@ -1,0 +1,20 @@
+# Codex React Dashboard
+
+This directory contains a small [Next.js](https://nextjs.org/) application that renders tasks from the `.tasks` directory in both table and kanban views.
+
+## Development
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The dashboard reads local task files during build time using `getStaticProps`. To generate a static site for GitHub Pages run:
+
+```bash
+npm run build
+```
+
+The output will be placed in the `out/` directory.

--- a/react-dashboard/components/Kanban.js
+++ b/react-dashboard/components/Kanban.js
@@ -1,0 +1,32 @@
+import React from 'react'
+
+function Column({ title, tasks }) {
+  return (
+    <div style={{ flex: 1, padding: '0 8px' }}>
+      <h3>{title}</h3>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {tasks.map(t => (
+          <li key={t.id} style={{ border: '1px solid #ccc', marginBottom: 4, padding: 4 }}>
+            {t.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default function Kanban({ tasks }) {
+  const columns = {
+    todo: tasks.filter(t => t.status === 'todo'),
+    in_progress: tasks.filter(t => t.status === 'in_progress'),
+    done: tasks.filter(t => t.status === 'done')
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <Column title="Todo" tasks={columns.todo} />
+      <Column title="In Progress" tasks={columns.in_progress} />
+      <Column title="Done" tasks={columns.done} />
+    </div>
+  )
+}

--- a/react-dashboard/components/TaskTable.js
+++ b/react-dashboard/components/TaskTable.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+export default function TaskTable({ tasks }) {
+  return (
+    <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Title</th>
+          <th>Status</th>
+          <th>Queue</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tasks.map(task => (
+          <tr key={task.id}>
+            <td>{task.id}</td>
+            <td>{task.title}</td>
+            <td>{task.status}</td>
+            <td>{task.id.split('-')[0]}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/react-dashboard/next.config.js
+++ b/react-dashboard/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  basePath: '/codex-utils'
+}
+
+module.exports = nextConfig

--- a/react-dashboard/package.json
+++ b/react-dashboard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codex-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.3.0",
+    "react-dom": "18.3.0"
+  }
+}

--- a/react-dashboard/pages/index.js
+++ b/react-dashboard/pages/index.js
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import path from 'path'
+import TaskTable from '../components/TaskTable'
+import Kanban from '../components/Kanban'
+
+export async function getStaticProps() {
+  const tasksDir = path.join(process.cwd(), '..', '.tasks')
+  let tasks = []
+  try {
+    const queues = fs.readdirSync(tasksDir)
+    for (const q of queues) {
+      const queueDir = path.join(tasksDir, q)
+      for (const file of fs.readdirSync(queueDir)) {
+        if (file.endsWith('.json')) {
+          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
+          tasks.push(data)
+        }
+      }
+    }
+  } catch {
+    // ignore errors for build portability
+  }
+  return { props: { tasks } }
+}
+
+export default function Home({ tasks }) {
+  return (
+    <div style={{ padding: 16 }}>
+      <h1>Task Dashboard</h1>
+      <h2>Table View</h2>
+      <TaskTable tasks={tasks} />
+      <h2>Kanban View</h2>
+      <Kanban tasks={tasks} />
+    </div>
+  )
+}


### PR DESCRIPTION
## What
- create `react-dashboard` Next.js project with table and kanban views
- document dashboard usage in README
- ignore node build artifacts
- update task DEV-14 status

## Why
Implements a basic React frontend for viewing tasks as requested in DEV-14.

## Verification
- `ruff check .`
- `mypy .`
- `pytest -q`
