### PR TITLE
[DEV-16] Add timestamps for task lifecycle

### DIFF
--- a/.tasks/DEV/DEV-16.json
+++ b/.tasks/DEV/DEV-16.json
@@ -2,8 +2,21 @@
   "id": "DEV-16",
   "title": "Add started_at and closed_at timestamp fields to tasks",
   "description": "Implement started_at and closed_at timestamp fields in the Task model to track when tasks are started and completed. Update the task start and done commands to set these timestamps.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Start DEV-16 implementation",
+      "created_at": 1748537328.7766197
+    },
+    {
+      "id": 2,
+      "text": "Implemented timestamps with tests",
+      "created_at": 1748537415.599759
+    }
+  ],
   "created_at": 1748534827.344876,
-  "updated_at": 1748534827.344876
+  "updated_at": 1748537415.5997863,
+  "started_at": null,
+  "closed_at": 1748537413.5284839
 }

--- a/task-manager/task_manager/cli.py
+++ b/task-manager/task_manager/cli.py
@@ -88,6 +88,10 @@ def task_show_cmd(args: argparse.Namespace, tm: TaskManager) -> int:
         print(f"Status: {task_data['status']}")
         print(f"Created: {format_timestamp(task_data.get('created_at', 0))}")
         print(f"Updated: {format_timestamp(task_data.get('updated_at', 0))}")
+        if task_data.get('started_at'):
+            print(f"Started: {format_timestamp(task_data['started_at'])}")
+        if task_data.get('closed_at'):
+            print(f"Closed: {format_timestamp(task_data['closed_at'])}")
 
         comments = task_data.get('comments', [])
         if comments:

--- a/task-manager/task_manager/core.py
+++ b/task-manager/task_manager/core.py
@@ -233,12 +233,40 @@ class TaskManager:
             return False
 
     def task_start(self, task_id: str) -> bool:
-        """Start a task (set status to 'in_progress')."""
-        return self.task_update(task_id, 'status', 'in_progress')
+        """Start a task (set status to 'in_progress' and record time)."""
+        task_data = self._load_task(task_id)
+        if not task_data:
+            logger.error(f"Error: Task '{task_id}' not found")
+            return False
+
+        task_data.status = 'in_progress'
+        if task_data.started_at is None:
+            task_data.started_at = time.time()
+
+        if self._save_task(task_data):
+            logger.info(f"Task '{task_id}' updated successfully")
+            return True
+        else:
+            logger.error(f"Error: Failed to update task '{task_id}'")
+            return False
 
     def task_done(self, task_id: str) -> bool:
-        """Mark a task as done (set status to 'done')."""
-        return self.task_update(task_id, 'status', 'done')
+        """Mark a task as done (set status to 'done' and record time)."""
+        task_data = self._load_task(task_id)
+        if not task_data:
+            logger.error(f"Error: Task '{task_id}' not found")
+            return False
+
+        task_data.status = 'done'
+        if task_data.closed_at is None:
+            task_data.closed_at = time.time()
+
+        if self._save_task(task_data):
+            logger.info(f"Task '{task_id}' updated successfully")
+            return True
+        else:
+            logger.error(f"Error: Failed to update task '{task_id}'")
+            return False
 
     def task_comment_add(self, task_id: str, comment: str) -> bool:
         """Add a comment to a task."""

--- a/task-manager/task_manager/models.py
+++ b/task-manager/task_manager/models.py
@@ -32,6 +32,8 @@ class Task:
     comments: List[Dict[str, Any]] = field(default_factory=list)
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    closed_at: float | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/task-manager/tests/test_task_management.py
+++ b/task-manager/tests/test_task_management.py
@@ -61,6 +61,8 @@ class TestTaskManagement(unittest.TestCase):
         self.assertEqual(task_data['comments'], [])
         self.assertIn('created_at', task_data)
         self.assertIn('updated_at', task_data)
+        self.assertIsNone(task_data.get('started_at'))
+        self.assertIsNone(task_data.get('closed_at'))
 
     def test_task_add_nonexistent_queue(self):
         """Test adding a task to a non-existent queue."""
@@ -200,6 +202,8 @@ class TestTaskManagement(unittest.TestCase):
         self.assertIn("Created:", result.stdout)
         self.assertIn("Updated:", result.stdout)
         self.assertIn("No comments", result.stdout)
+        self.assertNotIn("Started:", result.stdout)
+        self.assertNotIn("Closed:", result.stdout)
 
     def test_task_show_nonexistent(self):
         """Test showing details of non-existent task."""
@@ -290,6 +294,13 @@ class TestTaskManagement(unittest.TestCase):
         result = self.run_task_manager(["task", "show", "--id", "test-queue-1"])
         self.assertIn("Status: in_progress", result.stdout)
 
+        # Verify started_at timestamp was recorded
+        task_file = self.tasks_root / "test-queue" / "test-queue-1.json"
+        with open(task_file) as f:
+            data = json.load(f)
+        self.assertIsNotNone(data.get("started_at"))
+        self.assertIsNone(data.get("closed_at"))
+
     def test_task_done(self):
         """Test marking a task as done."""
         # Create a task
@@ -308,6 +319,12 @@ class TestTaskManagement(unittest.TestCase):
         # Verify status changed
         result = self.run_task_manager(["task", "show", "--id", "test-queue-1"])
         self.assertIn("Status: done", result.stdout)
+
+        # Verify closed_at timestamp was recorded
+        task_file = self.tasks_root / "test-queue" / "test-queue-1.json"
+        with open(task_file) as f:
+            data = json.load(f)
+        self.assertIsNotNone(data.get("closed_at"))
 
     def test_task_comment_add(self):
         """Test adding comments to a task."""


### PR DESCRIPTION
## Summary
- extend Task model with `started_at` and `closed_at`
- record start/close timestamps in `task_start` and `task_done`
- display timestamps in CLI task view
- update tests for new fields
- mark DEV-16 as complete

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`