### PR TITLE
[DEV-18] Create tasks for deletion/comment features

### DIFF
--- a/.tasks/DEV/DEV-18.json
+++ b/.tasks/DEV/DEV-18.json
@@ -1,0 +1,23 @@
+{
+  "id": "DEV-18",
+  "title": "Create tasks for deletion/comment features",
+  "description": "Add tasks in TM, TM_TUI, and TM_WEB queues",
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Created tasks in TM, TM_TUI, and TM_WEB queues",
+      "created_at": 1748540636.4972794
+    },
+    {
+      "id": 2,
+      "text": "Closing task after creating tasks for deletion/comment features",
+      "created_at": 1748540904.46206
+    }
+  ],
+  "links": {},
+  "created_at": 1748540631.587383,
+  "updated_at": 1748540904.6041026,
+  "started_at": 1748540634.0282278,
+  "closed_at": 1748540904.6040514
+}

--- a/.tasks/TM/TM-1.json
+++ b/.tasks/TM/TM-1.json
@@ -1,0 +1,17 @@
+{
+  "id": "TM-1",
+  "title": "Add task/queue deletion commands",
+  "description": "Implement CLI commands to delete tasks and queues",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM_TUI-1",
+      "TM_WEB-1"
+    ]
+  },
+  "created_at": 1748540578.1653335,
+  "updated_at": 1748540605.787068,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM/TM-2.json
+++ b/.tasks/TM/TM-2.json
@@ -1,0 +1,18 @@
+{
+  "id": "TM-2",
+  "title": "Edit task comments command",
+  "description": "Implement command to edit comments on tasks",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM_TUI-2",
+      "TM_TUI-3",
+      "TM_WEB-2"
+    ]
+  },
+  "created_at": 1748540580.5285208,
+  "updated_at": 1748540609.9751074,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM_TUI/TM_TUI-1.json
+++ b/.tasks/TM_TUI/TM_TUI-1.json
@@ -1,0 +1,16 @@
+{
+  "id": "TM_TUI-1",
+  "title": "Support deletion of tasks and queues",
+  "description": "Add TUI actions to remove tasks or queues",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM-1"
+    ]
+  },
+  "created_at": 1748540583.1323383,
+  "updated_at": 1748540603.5454617,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM_TUI/TM_TUI-2.json
+++ b/.tasks/TM_TUI/TM_TUI-2.json
@@ -1,0 +1,16 @@
+{
+  "id": "TM_TUI-2",
+  "title": "Add comments interface",
+  "description": "Provide TUI for viewing and adding comments",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM-2"
+    ]
+  },
+  "created_at": 1748540585.6959803,
+  "updated_at": 1748540606.6851642,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM_TUI/TM_TUI-3.json
+++ b/.tasks/TM_TUI/TM_TUI-3.json
@@ -1,0 +1,16 @@
+{
+  "id": "TM_TUI-3",
+  "title": "Edit and remove comments",
+  "description": "Allow editing and deleting comments from the TUI",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM-2"
+    ]
+  },
+  "created_at": 1748540588.2582066,
+  "updated_at": 1748540609.028882,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM_WEB/TM_WEB-1.json
+++ b/.tasks/TM_WEB/TM_WEB-1.json
@@ -1,0 +1,16 @@
+{
+  "id": "TM_WEB-1",
+  "title": "Add delete actions in web",
+  "description": "Enable deleting tasks and queues via dashboard",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM-1"
+    ]
+  },
+  "created_at": 1748540591.6116464,
+  "updated_at": 1748540605.786244,
+  "started_at": null,
+  "closed_at": null
+}

--- a/.tasks/TM_WEB/TM_WEB-2.json
+++ b/.tasks/TM_WEB/TM_WEB-2.json
@@ -1,0 +1,16 @@
+{
+  "id": "TM_WEB-2",
+  "title": "Edit and delete comments in web",
+  "description": "Allow editing and deleting comments from the dashboard",
+  "status": "todo",
+  "comments": [],
+  "links": {
+    "related": [
+      "TM-2"
+    ]
+  },
+  "created_at": 1748540594.3079424,
+  "updated_at": 1748540609.974294,
+  "started_at": null,
+  "closed_at": null
+}


### PR DESCRIPTION
## What
- close DEV-18 after adding tasks for CLI, TUI and web interfaces
- logged final comment on DEV-18

## Why
- tasks were created in previous commit, this finishes the work and marks the task done

## Verification
- `pytest -q`
- `ruff check .`
- `mypy .`
