### PR TITLE
[TM-1] Add task/queue deletion commands

### DIFF
--- a/.tasks/TM/TM-1.json
+++ b/.tasks/TM/TM-1.json
@@ -2,8 +2,24 @@
   "id": "TM-1",
   "title": "Add task/queue deletion commands",
   "description": "Implement CLI commands to delete tasks and queues",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on deletion commands",
+      "created_at": 1748542123.898095
+    },
+    {
+      "id": 2,
+      "text": "Implemented delete commands and tests",
+      "created_at": 1748542227.3164392
+    },
+    {
+      "id": 3,
+      "text": "Completed implementation",
+      "created_at": 1748542269.5371919
+    }
+  ],
   "links": {
     "related": [
       "TM_TUI-1",
@@ -11,7 +27,7 @@
     ]
   },
   "created_at": 1748540578.1653335,
-  "updated_at": 1748540605.787068,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748542269.5372279,
+  "started_at": 1748542121.7009246,
+  "closed_at": 1748542267.3872318
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Launch the interactive Textual interface:
 
 # Create a new queue
 ./tm queue add --name "feature-queue" --title "Feature Development" --description "Queue for new features"
+
+# Delete a queue
+./tm queue delete --name "feature-queue"
 ```
 
 ### Task Management
@@ -43,6 +46,9 @@ Launch the interactive Textual interface:
 # Start or finish work
 ./tm task start --id feature-queue-1
 ./tm task done --id feature-queue-1
+
+# Delete a task
+./tm task delete --id feature-queue-1
 ```
 
 ### Comment System

--- a/task-manager/task_manager/cli.py
+++ b/task-manager/task_manager/cli.py
@@ -32,9 +32,16 @@ def queue_add(args: argparse.Namespace, tm: TaskManager) -> int:
     return 0 if success else 1
 
 
+def queue_delete(args: argparse.Namespace, tm: TaskManager) -> int:
+    """Handle `queue delete` command."""
+    success = tm.queue_delete(args.name)
+    return 0 if success else 1
+
+
 QUEUE_ACTIONS: dict[str, Callable[[argparse.Namespace, TaskManager], int]] = {
     "list": queue_list,
     "add": queue_add,
+    "delete": queue_delete,
 }
 
 
@@ -77,6 +84,12 @@ def task_list_cmd(args: argparse.Namespace, tm: TaskManager) -> int:
 def task_add_cmd(args: argparse.Namespace, tm: TaskManager) -> int:
     task_id = tm.task_add(args.title, args.description, args.queue)
     return 0 if task_id else 1
+
+
+def task_delete_cmd(args: argparse.Namespace, tm: TaskManager) -> int:
+    """Handle `task delete` command."""
+    success = tm.task_delete(args.id)
+    return 0 if success else 1
 
 
 def task_show_cmd(args: argparse.Namespace, tm: TaskManager) -> int:
@@ -209,6 +222,7 @@ def handle_link(args: argparse.Namespace, tm: TaskManager) -> int:
 TASK_ACTIONS: dict[str, Callable[[argparse.Namespace, TaskManager], int]] = {
     "list": task_list_cmd,
     "add": task_add_cmd,
+    "delete": task_delete_cmd,
     "show": task_show_cmd,
     "update": task_update_cmd,
     "start": task_start_cmd,
@@ -304,6 +318,10 @@ def main():
     queue_add_parser.add_argument("--name", required=True, help="Queue name")
     queue_add_parser.add_argument("--title", required=True, help="Queue title")
     queue_add_parser.add_argument("--description", required=True, help="Queue description")
+
+    # queue delete
+    queue_delete_parser = queue_subparsers.add_parser("delete", help="Delete a queue")
+    queue_delete_parser.add_argument("--name", required=True, help="Queue name")
     
     # Task commands
     task_parser = subparsers.add_parser("task", help="Task management")
@@ -319,6 +337,10 @@ def main():
     task_add_parser.add_argument("--title", required=True, help="Task title")
     task_add_parser.add_argument("--description", required=True, help="Task description")
     task_add_parser.add_argument("--queue", required=True, help="Queue name")
+
+    # task delete
+    task_delete_parser = task_subparsers.add_parser("delete", help="Delete a task")
+    task_delete_parser.add_argument("--id", required=True, help="Task ID")
     
     # task show
     task_show_parser = task_subparsers.add_parser("show", help="Show task details")

--- a/task-manager/task_manager/core.py
+++ b/task-manager/task_manager/core.py
@@ -406,3 +406,35 @@ class TaskManager:
             return None
         return task_data.links
 
+    def queue_delete(self, name: str) -> bool:
+        """Delete an entire queue and all its tasks."""
+        queue_dir = self.tasks_root / name
+        if not queue_dir.exists() or not queue_dir.is_dir():
+            log_error(f"Error: Queue '{name}' not found")
+            return False
+
+        try:
+            import shutil
+
+            shutil.rmtree(queue_dir)
+            logger.info(f"Queue '{name}' deleted successfully")
+            return True
+        except (OSError, IOError) as e:
+            log_error(f"Error deleting queue '{name}': {e}")
+            return False
+
+    def task_delete(self, task_id: str) -> bool:
+        """Delete a task file from its queue."""
+        task_file = self._find_task_file(task_id)
+        if not task_file or not task_file.exists():
+            log_error(f"Error: Task '{task_id}' not found")
+            return False
+
+        try:
+            task_file.unlink()
+            logger.info(f"Task '{task_id}' deleted successfully")
+            return True
+        except (OSError, IOError) as e:
+            log_error(f"Error deleting task '{task_id}': {e}")
+            return False
+

--- a/task-manager/tests/test_queue_management.py
+++ b/task-manager/tests/test_queue_management.py
@@ -157,6 +157,31 @@ class TestQueueManagement(unittest.TestCase):
         result = self.run_task_manager(["queue", "invalid"])
         self.assertNotEqual(result.returncode, 0)
 
+    def test_queue_delete(self):
+        """Test deleting an existing queue."""
+        self.run_task_manager([
+            "queue",
+            "add",
+            "--name",
+            "del-queue",
+            "--title",
+            "Del",
+            "--description",
+            "To delete",
+        ])
+
+        result = self.run_task_manager([
+            "queue",
+            "delete",
+            "--name",
+            "del-queue",
+        ])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Queue 'del-queue' deleted successfully", result.stdout)
+
+        queue_dir = self.tasks_root / "del-queue"
+        self.assertFalse(queue_dir.exists())
+
     def test_tasks_root_creation(self):
         """Test that tasks root directory is created if it doesn't exist."""
         # Use a non-existent directory

--- a/task-manager/tests/test_task_management.py
+++ b/task-manager/tests/test_task_management.py
@@ -326,6 +326,31 @@ class TestTaskManagement(unittest.TestCase):
             data = json.load(f)
         self.assertIsNotNone(data.get("closed_at"))
 
+    def test_task_delete(self):
+        """Test deleting a task."""
+        self.run_task_manager([
+            "task",
+            "add",
+            "--title",
+            "Task to Delete",
+            "--description",
+            "Desc",
+            "--queue",
+            "test-queue",
+        ])
+
+        result = self.run_task_manager([
+            "task",
+            "delete",
+            "--id",
+            "test-queue-1",
+        ])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Task 'test-queue-1' deleted successfully", result.stdout)
+
+        task_file = self.tasks_root / "test-queue" / "test-queue-1.json"
+        self.assertFalse(task_file.exists())
+
     def test_task_comment_add(self):
         """Test adding comments to a task."""
         # Create a task

--- a/task-manager/tests/test_task_manager_internal.py
+++ b/task-manager/tests/test_task_manager_internal.py
@@ -246,6 +246,19 @@ class TestTaskManagerInternal(unittest.TestCase):
         self.assertEqual(len(comments), 1)
         self.assertEqual(comments[0]["text"], "c2")
 
+    def test_queue_delete_internal(self):
+        """Test deleting a queue via TaskManager."""
+        self.tm.queue_add("del", "Del", "desc")
+        self.assertTrue(self.tm.queue_delete("del"))
+        self.assertEqual(self.tm.queue_list(), [])
+
+    def test_task_delete_internal(self):
+        """Test deleting a task via TaskManager."""
+        self.tm.queue_add("q", "Queue", "desc")
+        task_id = self.tm.task_add("Task", "Desc", "q")
+        self.assertTrue(self.tm.task_delete(task_id))
+        self.assertEqual(self.tm.task_list(), [])
+
     def test_get_next_task_number_internal(self):
         """Test internal task numbering logic."""
         self.tm.queue_add("q", "Queue", "desc")


### PR DESCRIPTION
## What
- implement `queue delete` and `task delete` commands in CLI
- add `queue_delete` and `task_delete` methods to `TaskManager`
- document deletion commands in README
- test queue/task deletion from CLI and internal API
- mark TM-1 task as done

## Why
- allow removing obsolete queues and tasks directly from the command line

## Verification
- `ruff check .`
- `mypy .`
- `pytest -q`
