### PR TITLE
[TM_WEB-4] Separate task list and kanban board into different pages

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-4.json
+++ b/.tasks/TM_WEB/TM_WEB-4.json
@@ -2,11 +2,27 @@
   "id": "TM_WEB-4",
   "title": "Separate task list and kanban board into different pages",
   "description": "Split the current combined view into separate pages: one for task list view and another for kanban board view. This will improve navigation and allow users to choose their preferred view mode.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Start work on splitting dashboard views into separate pages",
+      "created_at": 1748551607.837413
+    },
+    {
+      "id": 2,
+      "text": "Implemented separated task views with table and kanban pages and updated navigation",
+      "created_at": 1748552064.2820592
+    },
+    {
+      "id": 3,
+      "text": "All tests passed",
+      "created_at": 1748552064.4201367
+    }
+  ],
   "links": {},
   "created_at": 1748551382.8842611,
-  "updated_at": 1748551382.8842611,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748552064.559595,
+  "started_at": 1748551606.7242832,
+  "closed_at": 1748552064.5595553
 }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ the `docs/` folder to GitHub Pages whenever changes are pushed to `main`.
 
 
 ### React Dashboard
-A Next.js frontend under `react-dashboard/` renders tasks in both table and kanban views.
+A Next.js frontend under `react-dashboard/` renders tasks. The task list and kanban board are available on separate pages.
 To develop locally:
 ```bash
 cd react-dashboard

--- a/react-dashboard/README.md
+++ b/react-dashboard/README.md
@@ -1,6 +1,6 @@
 # Codex React Dashboard
 
-This directory contains a small [Next.js](https://nextjs.org/) application that renders tasks from the `.tasks` directory in both table and kanban views.
+This directory contains a small [Next.js](https://nextjs.org/) application that renders tasks from the `.tasks` directory. The task list and kanban board are now available on separate pages.
 
 ## Development
 
@@ -15,7 +15,9 @@ The dashboard reads local task files during build time using `getStaticProps`.
 
 ### Pages
 
-- `/` - main dashboard with table and kanban views
+- `/` - home page
+- `/table` - task list view
+- `/kanban` - kanban board view
 - `/todo` - page showing only tasks with a `todo` status
 
 To generate a static site for GitHub Pages run:

--- a/react-dashboard/components/Navigation.js
+++ b/react-dashboard/components/Navigation.js
@@ -9,15 +9,29 @@ export default function Navigation() {
       marginBottom: '16px' 
     }}>
       <div style={{ display: 'flex', gap: '16px' }}>
-        <Link href="/" style={{ 
-          color: '#0070f3', 
+        <Link href="/" style={{
+          color: '#0070f3',
           textDecoration: 'none',
           fontWeight: 'bold'
         }}>
-          📊 Dashboard
+          🏠 Home
         </Link>
-        <Link href="/todo" style={{ 
-          color: '#0070f3', 
+        <Link href="/table" style={{
+          color: '#0070f3',
+          textDecoration: 'none',
+          fontWeight: 'bold'
+        }}>
+          📋 Task List
+        </Link>
+        <Link href="/kanban" style={{
+          color: '#0070f3',
+          textDecoration: 'none',
+          fontWeight: 'bold'
+        }}>
+          🗂 Kanban Board
+        </Link>
+        <Link href="/todo" style={{
+          color: '#0070f3',
           textDecoration: 'none',
           fontWeight: 'bold'
         }}>

--- a/react-dashboard/pages/index.js
+++ b/react-dashboard/pages/index.js
@@ -1,40 +1,11 @@
-import fs from 'fs'
-import path from 'path'
-import TaskTable from '../components/TaskTable'
-import Kanban from '../components/Kanban'
 import Navigation from '../components/Navigation'
 
-export async function getStaticProps() {
-  const tasksDir = path.join(process.cwd(), '..', '.tasks')
-  let tasks = []
-  try {
-    const queues = fs.readdirSync(tasksDir)
-    for (const q of queues) {
-      const queueDir = path.join(tasksDir, q)
-      for (const file of fs.readdirSync(queueDir)) {
-        if (file.endsWith('.json') && file !== 'meta.json') {
-          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
-          if (data.id) {
-            tasks.push(data)
-          }
-        }
-      }
-    }
-  } catch {
-    // ignore errors for build portability
-  }
-  return { props: { tasks } }
-}
-
-export default function Home({ tasks }) {
+export default function Home() {
   return (
     <div style={{ padding: 16 }}>
       <Navigation />
-      <h1>Task Dashboard</h1>
-      <h2>Table View</h2>
-      <TaskTable tasks={tasks} />
-      <h2>Kanban View</h2>
-      <Kanban tasks={tasks} />
+      <h1>Codex Dashboard</h1>
+      <p>Select a view from the navigation menu.</p>
     </div>
   )
 }

--- a/react-dashboard/pages/kanban.js
+++ b/react-dashboard/pages/kanban.js
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import path from 'path'
+import Kanban from '../components/Kanban'
+import Navigation from '../components/Navigation'
+
+export async function getStaticProps() {
+  const tasksDir = path.join(process.cwd(), '..', '.tasks')
+  let tasks = []
+  try {
+    const queues = fs.readdirSync(tasksDir)
+    for (const q of queues) {
+      const queueDir = path.join(tasksDir, q)
+      for (const file of fs.readdirSync(queueDir)) {
+        if (file.endsWith('.json') && file !== 'meta.json') {
+          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
+          if (data.id) {
+            tasks.push(data)
+          }
+        }
+      }
+    }
+  } catch {
+    // ignore errors for build portability
+  }
+  return { props: { tasks } }
+}
+
+export default function KanbanPage({ tasks }) {
+  return (
+    <div style={{ padding: 16 }}>
+      <Navigation />
+      <h1>Kanban Board</h1>
+      <Kanban tasks={tasks} />
+    </div>
+  )
+}

--- a/react-dashboard/pages/table.js
+++ b/react-dashboard/pages/table.js
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import path from 'path'
+import TaskTable from '../components/TaskTable'
+import Navigation from '../components/Navigation'
+
+export async function getStaticProps() {
+  const tasksDir = path.join(process.cwd(), '..', '.tasks')
+  let tasks = []
+  try {
+    const queues = fs.readdirSync(tasksDir)
+    for (const q of queues) {
+      const queueDir = path.join(tasksDir, q)
+      for (const file of fs.readdirSync(queueDir)) {
+        if (file.endsWith('.json') && file !== 'meta.json') {
+          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
+          if (data.id) {
+            tasks.push(data)
+          }
+        }
+      }
+    }
+  } catch {
+    // ignore errors for build portability
+  }
+  return { props: { tasks } }
+}
+
+export default function TablePage({ tasks }) {
+  return (
+    <div style={{ padding: 16 }}>
+      <Navigation />
+      <h1>Task List</h1>
+      <TaskTable tasks={tasks} />
+    </div>
+  )
+}


### PR DESCRIPTION
## What
- finalize work for TM_WEB-4 by marking the task complete
- include closing comments in `.tasks/TM_WEB/TM_WEB-4.json`

## Why
- properly close the task after implementing the new dashboard pages

## Verification
- `ruff check .`
- `mypy .`
- `pytest -q`
