### PR TITLE
[TM_WEB-8] Refactor data loading into reusable hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!react-dashboard/lib/
 lib64/
 parts/
 sdist/

--- a/.tasks/TM_WEB/TM_WEB-8.json
+++ b/.tasks/TM_WEB/TM_WEB-8.json
@@ -2,15 +2,26 @@
   "id": "TM_WEB-8",
   "title": "Refactor data loading into reusable hook",
   "description": "Create a custom React hook to load tasks from .tasks directory and share logic between pages",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting task work",
+      "created_at": 1748554246.0895278
+    },
+    {
+      "id": 2,
+      "text": "Implemented useTasks hook and API, updated pages to use it",
+      "created_at": 1748554398.3414428
+    }
+  ],
   "links": {
     "related": [
       "DEV-21"
     ]
   },
   "created_at": 1748553428.3552904,
-  "updated_at": 1748553439.7551897,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748554400.8065505,
+  "started_at": 1748554245.005533,
+  "closed_at": 1748554400.8065233
 }

--- a/react-dashboard/README.md
+++ b/react-dashboard/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-The dashboard reads local task files during build time using `getStaticProps`.
+The dashboard loads tasks at runtime using a shared React hook and API route.
 
 ### Pages
 

--- a/react-dashboard/hooks/useTasks.js
+++ b/react-dashboard/hooks/useTasks.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+export default function useTasks() {
+  const [tasks, setTasks] = useState([])
+
+  useEffect(() => {
+    async function fetchTasks() {
+      try {
+        const res = await fetch('/api/tasks')
+        const data = await res.json()
+        setTasks(data.tasks || [])
+      } catch {
+        setTasks([])
+      }
+    }
+    fetchTasks()
+  }, [])
+
+  return tasks
+}

--- a/react-dashboard/lib/tasks.js
+++ b/react-dashboard/lib/tasks.js
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+
+export function loadTasks() {
+  const tasksDir = path.join(process.cwd(), '..', '.tasks')
+  const tasks = []
+  try {
+    const queues = fs.readdirSync(tasksDir)
+    for (const q of queues) {
+      const queueDir = path.join(tasksDir, q)
+      for (const file of fs.readdirSync(queueDir)) {
+        if (file.endsWith('.json') && file !== 'meta.json') {
+          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
+          if (data.id) {
+            tasks.push(data)
+          }
+        }
+      }
+    }
+  } catch {
+    // ignore errors for build portability
+  }
+  return tasks
+}

--- a/react-dashboard/pages/api/tasks.js
+++ b/react-dashboard/pages/api/tasks.js
@@ -1,0 +1,6 @@
+import { loadTasks } from '../../lib/tasks'
+
+export default function handler(req, res) {
+  const tasks = loadTasks()
+  res.status(200).json({ tasks })
+}

--- a/react-dashboard/pages/kanban.js
+++ b/react-dashboard/pages/kanban.js
@@ -1,31 +1,10 @@
-import fs from 'fs'
-import path from 'path'
 import Kanban from '../components/Kanban'
 import Navigation from '../components/Navigation'
+import useTasks from '../hooks/useTasks'
 
-export async function getStaticProps() {
-  const tasksDir = path.join(process.cwd(), '..', '.tasks')
-  let tasks = []
-  try {
-    const queues = fs.readdirSync(tasksDir)
-    for (const q of queues) {
-      const queueDir = path.join(tasksDir, q)
-      for (const file of fs.readdirSync(queueDir)) {
-        if (file.endsWith('.json') && file !== 'meta.json') {
-          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
-          if (data.id) {
-            tasks.push(data)
-          }
-        }
-      }
-    }
-  } catch {
-    // ignore errors for build portability
-  }
-  return { props: { tasks } }
-}
+export default function KanbanPage() {
+  const tasks = useTasks()
 
-export default function KanbanPage({ tasks }) {
   return (
     <div style={{ padding: 16 }}>
       <Navigation />

--- a/react-dashboard/pages/table.js
+++ b/react-dashboard/pages/table.js
@@ -1,31 +1,10 @@
-import fs from 'fs'
-import path from 'path'
 import TaskTable from '../components/TaskTable'
 import Navigation from '../components/Navigation'
+import useTasks from '../hooks/useTasks'
 
-export async function getStaticProps() {
-  const tasksDir = path.join(process.cwd(), '..', '.tasks')
-  let tasks = []
-  try {
-    const queues = fs.readdirSync(tasksDir)
-    for (const q of queues) {
-      const queueDir = path.join(tasksDir, q)
-      for (const file of fs.readdirSync(queueDir)) {
-        if (file.endsWith('.json') && file !== 'meta.json') {
-          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
-          if (data.id) {
-            tasks.push(data)
-          }
-        }
-      }
-    }
-  } catch {
-    // ignore errors for build portability
-  }
-  return { props: { tasks } }
-}
+export default function TablePage() {
+  const tasks = useTasks()
 
-export default function TablePage({ tasks }) {
   return (
     <div style={{ padding: 16 }}>
       <Navigation />

--- a/react-dashboard/pages/todo.js
+++ b/react-dashboard/pages/todo.js
@@ -1,31 +1,11 @@
-import fs from 'fs'
-import path from 'path'
 import TaskTable from '../components/TaskTable'
 import Navigation from '../components/Navigation'
+import useTasks from '../hooks/useTasks'
 
-export async function getStaticProps() {
-  const tasksDir = path.join(process.cwd(), '..', '.tasks')
-  let tasks = []
-  try {
-    const queues = fs.readdirSync(tasksDir)
-    for (const q of queues) {
-      const queueDir = path.join(tasksDir, q)
-      for (const file of fs.readdirSync(queueDir)) {
-        if (file.endsWith('.json') && file !== 'meta.json') {
-          const data = JSON.parse(fs.readFileSync(path.join(queueDir, file), 'utf8'))
-          if (data.id && data.status === 'todo') {
-            tasks.push(data)
-          }
-        }
-      }
-    }
-  } catch (error) {
-    console.error('Error reading tasks directory:', error);
-  }
-  return { props: { tasks } }
-}
+export default function TodoPage() {
+  const allTasks = useTasks()
+  const tasks = allTasks.filter(t => t.status === 'todo')
 
-export default function TodoPage({ tasks }) {
   return (
     <div style={{ padding: 16 }}>
       <Navigation />


### PR DESCRIPTION
## Summary
- create reusable `useTasks` hook
- add `/api/tasks` endpoint and shared `loadTasks` helper
- refactor pages to use the hook
- document new runtime data loading in dashboard README

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
