### PR TITLE
[TM_WEB-10] Implement global state management

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-10.json
+++ b/.tasks/TM_WEB/TM_WEB-10.json
@@ -2,15 +2,26 @@
   "id": "TM_WEB-10",
   "title": "Implement global state management",
   "description": "Use React context or state management library for tasks to reduce prop drilling",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Started working on implementing global state management",
+      "created_at": 1748556475.025279
+    },
+    {
+      "id": 2,
+      "text": "Implemented TaskProvider context and updated components to use global tasks state",
+      "created_at": 1748556580.4329457
+    }
+  ],
   "links": {
     "related": [
       "DEV-21"
     ]
   },
   "created_at": 1748553432.1043518,
-  "updated_at": 1748553441.5037804,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748556582.146319,
+  "started_at": 1748556472.9148653,
+  "closed_at": 1748556582.1462955
 }

--- a/react-dashboard/components/Kanban.js
+++ b/react-dashboard/components/Kanban.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import useTasks from '../hooks/useTasks'
 import styles from './Kanban.module.css'
 
 function Column({ title, tasks }) {
@@ -16,7 +17,8 @@ function Column({ title, tasks }) {
   )
 }
 
-export default function Kanban({ tasks }) {
+export default function Kanban() {
+  const tasks = useTasks()
   const columns = {
     todo: tasks.filter(t => t.status === 'todo'),
     in_progress: tasks.filter(t => t.status === 'in_progress'),

--- a/react-dashboard/components/TaskTable.js
+++ b/react-dashboard/components/TaskTable.js
@@ -1,9 +1,11 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import Link from 'next/link'
+import useTasks from '../hooks/useTasks'
 import styles from './TaskTable.module.css'
 
 
-export default function TaskTable({ tasks }) {
+export default function TaskTable({ tasks: tasksProp }) {
+  const tasks = tasksProp ?? useTasks()
   const [pageSize, setPageSize] = useState(10)
   const [page, setPage] = useState(0)
   const [statusFilter, setStatusFilter] = useState('')

--- a/react-dashboard/context/TaskContext.js
+++ b/react-dashboard/context/TaskContext.js
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const TaskContext = createContext({ tasks: [], setTasks: () => {} })
+
+export function TaskProvider({ children }) {
+  const [tasks, setTasks] = useState([])
+
+  useEffect(() => {
+    async function fetchTasks() {
+      try {
+        const res = await fetch('/codex-utils/tasks.json')
+        const data = await res.json()
+        setTasks(data || [])
+      } catch {
+        setTasks([])
+      }
+    }
+    fetchTasks()
+  }, [])
+
+  return (
+    <TaskContext.Provider value={{ tasks, setTasks }}>
+      {children}
+    </TaskContext.Provider>
+  )
+}
+
+export function useTaskContext() {
+  return useContext(TaskContext)
+}

--- a/react-dashboard/hooks/useTasks.js
+++ b/react-dashboard/hooks/useTasks.js
@@ -1,21 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useTaskContext } from '../context/TaskContext'
 
 export default function useTasks() {
-  const [tasks, setTasks] = useState([])
-
-  useEffect(() => {
-    async function fetchTasks() {
-      try {
-        // For static export, we need to load tasks from a pre-generated JSON file
-        const res = await fetch('/codex-utils/tasks.json')
-        const data = await res.json()
-        setTasks(data || [])
-      } catch {
-        setTasks([])
-      }
-    }
-    fetchTasks()
-  }, [])
-
+  const { tasks } = useTaskContext()
   return tasks
 }

--- a/react-dashboard/pages/_app.js
+++ b/react-dashboard/pages/_app.js
@@ -1,0 +1,9 @@
+import { TaskProvider } from '../context/TaskContext'
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <TaskProvider>
+      <Component {...pageProps} />
+    </TaskProvider>
+  )
+}

--- a/react-dashboard/pages/kanban.js
+++ b/react-dashboard/pages/kanban.js
@@ -1,16 +1,13 @@
 import Kanban from '../components/Kanban'
 import Navigation from '../components/Navigation'
-import useTasks from '../hooks/useTasks'
 import styles from './Page.module.css'
 
 export default function KanbanPage() {
-  const tasks = useTasks()
-
   return (
     <div className={styles.container}>
       <Navigation />
       <h1>Kanban Board</h1>
-      <Kanban tasks={tasks} />
+      <Kanban />
     </div>
   )
 }

--- a/react-dashboard/pages/table.js
+++ b/react-dashboard/pages/table.js
@@ -1,16 +1,13 @@
 import TaskTable from '../components/TaskTable'
 import Navigation from '../components/Navigation'
-import useTasks from '../hooks/useTasks'
 import styles from './Page.module.css'
 
 export default function TablePage() {
-  const tasks = useTasks()
-
   return (
     <div className={styles.container}>
       <Navigation />
       <h1>Task List</h1>
-      <TaskTable tasks={tasks} />
+      <TaskTable />
     </div>
   )
 }


### PR DESCRIPTION
## What
- create a `TaskProvider` using React context
- update hooks and components to consume tasks via context
- add `_app.js` to wrap pages with the provider
- adjust pages to rely on the new global state

## Why
- centralizes task data so pages and components no longer fetch tasks individually
- reduces prop drilling by letting components access tasks directly from context

## Verification
- `ruff check .`
- `pytest`
- `mypy .`
