### PR TITLE
[TM-5] Implement caching for task and queue lists

### DIFF
--- a/.tasks/TM/TM-5.json
+++ b/.tasks/TM/TM-5.json
@@ -2,15 +2,26 @@
   "id": "TM-5",
   "title": "Implement caching for task and queue lists",
   "description": "Cache list results to improve performance with large datasets",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on caching.",
+      "created_at": 1748615131.0922077
+    },
+    {
+      "id": 2,
+      "text": "Implemented caching and tests.",
+      "created_at": 1748615293.4572637
+    }
+  ],
   "links": {
     "related": [
       "DEV-19"
     ]
   },
   "created_at": 1748553478.0440648,
-  "updated_at": 1748553484.6664433,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748615294.6203852,
+  "started_at": 1748615128.7236488,
+  "closed_at": 1748615294.6203594
 }


### PR DESCRIPTION
## What
- add in-memory caches to `TaskManager.queue_list` and `TaskManager.task_list`
- invalidate caches after mutating operations
- update unit tests to verify caching behaviour
- record task TM-5 progress

## Why
Caching avoids reloading files on every list operation which improves performance with large numbers of tasks or queues.

## Verification
- `ruff check .`
- `mypy .`
- `pytest -q`
