### PR TITLE
[TM_TUI-6] Add tests for TUI

### DIFF
--- a/.tasks/TM_TUI/TM_TUI-6.json
+++ b/.tasks/TM_TUI/TM_TUI-6.json
@@ -2,11 +2,32 @@
   "id": "TM_TUI-6",
   "title": "Add tests for TUI",
   "description": "Use textual's test utilities to cover basic workflows",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Started implementing TUI tests",
+      "created_at": 1748620925.1069994
+    },
+    {
+      "id": 2,
+      "text": "Added basic navigation test with Textual run_test",
+      "created_at": 1748620928.3298776
+    },
+    {
+      "id": 3,
+      "text": "Verified ruff, mypy, pytest all pass",
+      "created_at": 1748620931.3414547
+    },
+    {
+      "id": 4,
+      "text": "Task completed",
+      "created_at": 1748620946.1025445
+    }
+  ],
   "links": {},
   "created_at": 1748553504.270316,
-  "updated_at": 1748553504.2703166,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748620946.1025808,
+  "started_at": 1748620921.6596541,
+  "closed_at": 1748620943.2239778
 }

--- a/task-manager/tests/test_tui.py
+++ b/task-manager/tests/test_tui.py
@@ -1,0 +1,31 @@
+import tempfile
+import unittest
+from task_manager.core import TaskManager
+from task_manager.tui import TMApp, MainScreen, QueuesScreen, TasksScreen
+
+
+class TestTuiNavigation(unittest.IsolatedAsyncioTestCase):
+    async def test_basic_navigation(self) -> None:
+        tasks_dir = tempfile.mkdtemp()
+        manager = TaskManager(tasks_dir)
+        async with TMApp(manager).run_test() as pilot:
+            # Should start on main screen
+            self.assertIsInstance(pilot.app.screen, MainScreen)
+
+            # Open queues screen and return
+            await pilot.press("1")
+            await pilot.pause()
+            self.assertIsInstance(pilot.app.screen, QueuesScreen)
+
+            await pilot.press("escape")
+            await pilot.pause()
+            self.assertIsInstance(pilot.app.screen, MainScreen)
+
+            # Open tasks screen
+            await pilot.press("2")
+            await pilot.pause()
+            self.assertIsInstance(pilot.app.screen, TasksScreen)
+
+            # Quit the application
+            await pilot.press("q")
+


### PR DESCRIPTION
## What changed and why
- implemented `test_tui.py` using Textual's `run_test` pilot to cover basic navigation workflows
- updated TM_TUI-6 task record to mark work completed

## Verification
- `pytest -q` → **77 passed**
- `ruff check .` → **All checks passed!**
- `mypy .` → **Success: no issues found in 20 source files**
