### PR TITLE
[TM_WEB-14] Update Web dashboard for exception handling

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-14.json
+++ b/.tasks/TM_WEB/TM_WEB-14.json
@@ -2,8 +2,19 @@
   "id": "TM_WEB-14",
   "title": "Update Web dashboard for exception handling",
   "description": "Adapt web interface to display errors from core",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting TM_WEB-14",
+      "created_at": 1748620687.377212
+    },
+    {
+      "id": 2,
+      "text": "Display detailed API errors",
+      "created_at": 1748620802.4171083
+    }
+  ],
   "links": {
     "related": [
       "TM-4",
@@ -11,7 +22,7 @@
     ]
   },
   "created_at": 1748553472.921496,
-  "updated_at": 1748553491.5766253,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748620802.4171355,
+  "started_at": 1748620684.2745588,
+  "closed_at": 1748620799.116825
 }

--- a/react-dashboard/pages/task/[id].tsx
+++ b/react-dashboard/pages/task/[id].tsx
@@ -65,16 +65,26 @@ export default function TaskPage({ task }: TaskPageProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: task.id, updates: { title, status } })
       })
+
+      const data = await res.json().catch(() => null)
+
       if (!res.ok) {
-        throw new Error(`Request failed: ${res.status} ${res.statusText}`)
+        const message = data && typeof data.error === 'string'
+          ? data.error
+          : `Request failed: ${res.status} ${res.statusText}`
+        throw new Error(message)
       }
-      const data = await res.json()
-      if (data.task) {
+
+      if (data && data.task) {
         setTasks((ts: Task[]) => ts.map((t: Task) => (t.id === task.id ? { ...t, ...data.task } : t)))
       }
       setSuccess(true)
-    } catch {
-      setError('Failed to update task')
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError('Failed to update task')
+      }
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
## What
- display detailed API errors in task page
- log work on TM_WEB-14 task

## Why
- new TaskManager exceptions surface specific messages that should be shown to the user

## Verification
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6839d4f06e208333a3ad19dc8cfe4d6c