### PR TITLE
[TM_WEB-19] Improve task sorting order

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-19.json
+++ b/.tasks/TM_WEB/TM_WEB-19.json
@@ -2,11 +2,17 @@
   "id": "TM_WEB-19",
   "title": "Improve task sorting in table",
   "description": "Fix task sorting in the web dashboard table. Currently tasks are sorted lexicographically by ID, which causes incorrect ordering (e.g., TM_WEB-2 appears after TM_WEB-18). Implement proper numeric sorting for task IDs to ensure correct chronological order.",
-  "status": "todo",
-  "comments": [],
+  "status": "in_progress",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Started work on numeric sorting",
+      "created_at": 1748890631.1613927
+    }
+  ],
   "links": {},
   "created_at": 1748620378.743814,
-  "updated_at": 1748620378.743814,
-  "started_at": null,
+  "updated_at": 1748890631.1614187,
+  "started_at": 1748890627.4377182,
   "closed_at": null
 }

--- a/react-dashboard/components/TaskTable.tsx
+++ b/react-dashboard/components/TaskTable.tsx
@@ -6,6 +6,13 @@ import { TaskTableProps, Task } from '../types'
 
 export default function TaskTable({ tasks: tasksProp }: TaskTableProps) {
   const tasks = tasksProp ?? useTasks()
+  const sortedTasks = useMemo(() => {
+    const parseId = (id: string): number => {
+      const num = parseInt(id.split('-')[1], 10)
+      return isNaN(num) ? Number.MAX_SAFE_INTEGER : num
+    }
+    return [...tasks].sort((a: Task, b: Task) => parseId(a.id) - parseId(b.id))
+  }, [tasks])
   const [pageSize, setPageSize] = useState<number>(10)
   const [page, setPage] = useState<number>(0)
   const [statusFilter, setStatusFilter] = useState<string>('')
@@ -17,7 +24,7 @@ export default function TaskTable({ tasks: tasksProp }: TaskTableProps) {
     [tasks]
   )
 
-  const filteredTasks = tasks.filter((t: Task) => {
+  const filteredTasks = sortedTasks.filter((t: Task) => {
     if (statusFilter && t.status !== statusFilter) return false
     if (queueFilter && !(t.id || '').startsWith(queueFilter + '-')) return false
     if (search && !t.title.toLowerCase().includes(search.toLowerCase())) return false


### PR DESCRIPTION
## Summary
- sort tasks numerically by id in the task table

## Testing
- `npm test`
- `pytest`
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_683df2d9ae30833381455576b9d124bd