### PR TITLE
[TM_WEB-23] Implement task sync

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-23.json
+++ b/.tasks/TM_WEB/TM_WEB-23.json
@@ -2,15 +2,26 @@
   "id": "TM_WEB-23",
   "title": "Implement task synchronization with GitHub repository",
   "description": "Create functionality to read tasks from GitHub repository files (.tasks/ directory) and sync with local task manager data. Handle file parsing and data mapping.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on GitHub task sync functionality",
+      "created_at": 1748931117.717148
+    },
+    {
+      "id": 2,
+      "text": "Implemented GitHub sync and tests",
+      "created_at": 1748931421.513349
+    }
+  ],
   "links": {
     "related": [
       "TM_WEB-22"
     ]
   },
   "created_at": 1748887663.91928,
-  "updated_at": 1748887697.1609879,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748931421.5133965,
+  "started_at": 1748931115.8372383,
+  "closed_at": 1748931418.248662
 }

--- a/task-manager/task_manager/cli.py
+++ b/task-manager/task_manager/cli.py
@@ -321,11 +321,23 @@ def handle_dashboard(args: argparse.Namespace, tm: TaskManager) -> int:
     return 0
 
 
+def handle_sync(args: argparse.Namespace, tm: TaskManager) -> int:
+    repos = args.repo or []
+    if not repos:
+        print("At least one --repo is required")
+        return 1
+
+    imported = tm.sync_from_github(repos, args.token)
+    print(f"Imported {len(imported)} tasks")
+    return 0
+
+
 COMMAND_HANDLERS: dict[str, Callable[[argparse.Namespace, TaskManager], int]] = {
     "queue": handle_queue,
     "task": handle_task,
     "ui": handle_ui,
     "dashboard": handle_dashboard,
+    "sync": handle_sync,
 }
 
 def main():
@@ -363,6 +375,21 @@ def main():
         help="GitHub repository in owner/repo format (can be used multiple times)",
     )
     dashboard_parser.add_argument(
+        "--token",
+        help="GitHub token for authenticated requests",
+    )
+
+    # Sync command
+    sync_parser = subparsers.add_parser(
+        "sync", help="Sync tasks from GitHub repositories"
+    )
+    sync_parser.add_argument(
+        "--repo",
+        action="append",
+        required=True,
+        help="GitHub repository in owner/repo format (can be used multiple times)",
+    )
+    sync_parser.add_argument(
         "--token",
         help="GitHub token for authenticated requests",
     )

--- a/task-manager/tests/test_github_sync.py
+++ b/task-manager/tests/test_github_sync.py
@@ -1,0 +1,36 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from task_manager import TaskManager
+
+
+class TestGitHubSync(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp()
+        self.tasks_root = Path(self.temp_dir) / "tasks"
+        self.tm = TaskManager(str(self.tasks_root))
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self.temp_dir)
+
+    def test_sync_from_github(self) -> None:
+        task_data = {"id": "DEV-1", "title": "Remote", "description": "Desc"}
+        with patch("task_manager.core.fetch_github_tasks", return_value=[task_data]):
+            ids = self.tm.sync_from_github(["owner/repo"])
+        self.assertEqual(ids, ["DEV-1"])
+        task_file = self.tasks_root / "DEV" / "DEV-1.json"
+        self.assertTrue(task_file.exists())
+        with open(task_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(data["title"], "Remote")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why
- add `sync_from_github` method to import tasks from GitHub
- expose new `sync` CLI command
- added tests for GitHub sync
- closed TM_WEB-23 task

## Verification steps
- `pytest`
- `ruff check .`
- `mypy .`
- `cd react-dashboard && npm test`


------
https://chatgpt.com/codex/tasks/task_e_683e91e5f6608333a9b80ac7a1d352ff