### PR TITLE
[TM_WEB-25] Add task updates via GitHub API

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-25.json
+++ b/.tasks/TM_WEB/TM_WEB-25.json
@@ -2,15 +2,26 @@
   "id": "TM_WEB-25",
   "title": "Add task updates via GitHub API",
   "description": "Implement task editing functionality through GitHub API. Handle task status changes, field updates, and comment additions by updating repository files.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on implementing GitHub API updates in React web dashboard",
+      "created_at": 1748936524.4575396
+    },
+    {
+      "id": 2,
+      "text": "Implemented updateTaskInRepo and tests",
+      "created_at": 1748936744.6043723
+    }
+  ],
   "links": {
     "related": [
       "TM_WEB-22"
     ]
   },
   "created_at": 1748887672.629698,
-  "updated_at": 1748887701.179368,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748936747.5595448,
+  "started_at": 1748936522.6276298,
+  "closed_at": 1748936747.5594864
 }

--- a/react-dashboard/lib/githubTasks.test.ts
+++ b/react-dashboard/lib/githubTasks.test.ts
@@ -1,4 +1,4 @@
-import { fetchTasksFromRepo, createTaskInRepo } from './githubTasks';
+import { fetchTasksFromRepo, createTaskInRepo, updateTaskInRepo } from './githubTasks';
 import { safeGitHubCall } from './githubClient';
 
 jest.mock('./githubClient', () => ({
@@ -54,5 +54,29 @@ describe('createTaskInRepo', () => {
   test('throws error for invalid repo string', async () => {
     const task = { id: 'TM_WEB-2', title: 'demo', status: 'todo' as const }
     await expect(createTaskInRepo('invalidrepo', task)).rejects.toThrow()
+  })
+})
+
+describe('updateTaskInRepo', () => {
+  test('calls safeGitHubCall with correct parameters', async () => {
+    const task = { id: 'TM_WEB-5', title: 'demo', status: 'todo' as const }
+
+    const result = await updateTaskInRepo('owner/repo', task, 'tkn')
+    expect(result).toBe(true)
+    const callArgs = (safeGitHubCall as unknown as jest.Mock).mock.calls.pop()
+    expect(typeof callArgs[0]).toBe('function')
+    expect(callArgs[1]).toBe('tkn')
+  })
+
+  test('returns false when safeGitHubCall fails', async () => {
+    ;(safeGitHubCall as unknown as jest.Mock).mockResolvedValueOnce(null)
+    const task = { id: 'TM_WEB-6', title: 'demo', status: 'todo' as const }
+    const result = await updateTaskInRepo('owner/repo', task, 'tkn')
+    expect(result).toBe(false)
+  })
+
+  test('throws error for invalid repo string', async () => {
+    const task = { id: 'TM_WEB-7', title: 'demo', status: 'todo' as const }
+    await expect(updateTaskInRepo('invalidrepo', task)).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## What
- add `updateTaskInRepo` helper to save edited tasks to GitHub
- test new function alongside existing helpers
- close TM_WEB-25 task tracking

## Why
- implement task editing capability in the React dashboard via GitHub API

## Verification
- `./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_683ea70776448333b32d9afad6936dc5