### PR TITLE
[TM-12] Add Epic tests and documentation

### DIFF
--- a/.tasks/TM/TM-12.json
+++ b/.tasks/TM/TM-12.json
@@ -2,15 +2,31 @@
   "id": "TM-12",
   "title": "Add Epic tests and documentation",
   "description": "Create comprehensive tests for Epic functionality: unit tests for Epic model, CLI commands, status validation, and hierarchical operations. Add Epic documentation and usage examples.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on epic tests and docs",
+      "created_at": 1748976407.6989946
+    },
+    {
+      "id": 2,
+      "text": "Implemented new epic tests and documentation updates",
+      "created_at": 1748976585.472086
+    },
+    {
+      "id": 3,
+      "text": "All tests pass; closing task",
+      "created_at": 1748976673.3398225
+    }
+  ],
   "links": {
     "related": [
       "TM-11"
     ]
   },
   "created_at": 1748891427.629737,
-  "updated_at": 1748891439.197525,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748976673.3398461,
+  "started_at": 1748976405.726318,
+  "closed_at": 1748976670.6123326
 }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Launch the interactive Textual interface:
 ./tm task link remove --id feature-queue-1 --target-id feature-queue-2
 ```
 
+### Epic Management
+```bash
+# Create an epic
+./tm epic add --title "Release" --description "Release preparations"
+
+# Attach work items
+./tm epic add-task --id epic-1 --task-id feature-queue-1
+./tm epic add-epic --id epic-1 --child-id epic-2
+
+# Close when all children are done
+./tm epic done --id epic-1
+```
+
 ### Typical Workflow
 1. **Create a queue**: `./tm queue add --name "my-queue" --title "My Queue" --description "Description"`.
 2. **Add a task**: `./tm task add --title "Task title" --description "Description" --queue my-queue`.

--- a/docs/epic_model.md
+++ b/docs/epic_model.md
@@ -26,3 +26,19 @@ stored as a JSON file named `<epic-id>.json` using the fields defined above.
 
 This flat structure mirrors the task storage convention and will be used by the
 persistence layer implemented in later tasks.
+
+## CLI Usage
+The `tm` command offers helpers for managing epics from the command line:
+
+```bash
+# Create and list epics
+./tm epic add --title "Release" --description "Release tasks"
+./tm epic list
+
+# Relate tasks or sub epics
+./tm epic add-task --id epic-1 --task-id q-1
+./tm epic add-epic --id epic-1 --child-id epic-2
+
+# Close an epic when all children are done
+./tm epic done --id epic-1
+```

--- a/task-manager/tests/test_epic_cli.py
+++ b/task-manager/tests/test_epic_cli.py
@@ -76,6 +76,19 @@ class TestEpicCLI(unittest.TestCase):
         show = self.run_tm(["epic", "show", "--id", "epic-1"])
         self.assertIn("closed", show.stdout)
 
+    def test_epic_remove_relations(self):
+        self.run_tm(["queue", "add", "--name", "q", "--title", "Q", "--description", "d"])
+        self.run_tm(["task", "add", "--title", "T", "--description", "d", "--queue", "q"])
+        self.run_tm(["epic", "add", "--title", "Parent", "--description", "d"])
+        self.run_tm(["epic", "add", "--title", "Child", "--description", "d"])
+        self.run_tm(["epic", "add-task", "--id", "epic-1", "--task-id", "q-1"])
+        self.run_tm(["epic", "add-epic", "--id", "epic-1", "--child-id", "epic-2"])
+        self.run_tm(["epic", "remove-task", "--id", "epic-1", "--task-id", "q-1"])
+        self.run_tm(["epic", "remove-epic", "--id", "epic-1", "--child-id", "epic-2"])
+        show = self.run_tm(["epic", "show", "--id", "epic-1"])
+        self.assertNotIn("q-1", show.stdout)
+        self.assertNotIn("epic-2", show.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/task-manager/tests/test_epic_model.py
+++ b/task-manager/tests/test_epic_model.py
@@ -1,0 +1,23 @@
+import unittest
+from task_manager.models import Epic, EpicStatus
+
+class TestEpicModel(unittest.TestCase):
+    def test_to_dict_from_dict(self):
+        original = Epic(
+            id="epic-1",
+            title="Title",
+            description="Desc",
+            status=EpicStatus.OPEN,
+            child_tasks=["t-1"],
+            child_epics=["epic-2"],
+            parent_epic=None,
+            created_at=1.0,
+            updated_at=2.0,
+        )
+        data = original.to_dict()
+        self.assertEqual(data["status"], "open")
+        clone = Epic.from_dict(data)
+        self.assertEqual(clone, original)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/task-manager/tests/test_epic_status_validation.py
+++ b/task-manager/tests/test_epic_status_validation.py
@@ -1,0 +1,32 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from task_manager import TaskManager
+
+class TestEpicStatusValidation(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.mkdtemp()
+        self.tasks_root = Path(self.temp) / "tasks"
+        self.epics_root = Path(self.temp) / "epics"
+        self.tm = TaskManager(str(self.tasks_root), epics_root=str(self.epics_root))
+        self.tm.queue_add("q", "Q", "d")
+        self.task_id = self.tm.task_add("T", "D", "q")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp)
+
+    def test_invalid_closed_epics(self):
+        epic_id = self.tm.epic_add("E", "D")
+        self.tm.epic_add_task(epic_id, self.task_id)
+        path = self.epics_root / f"{epic_id}.json"
+        data = json.loads(path.read_text())
+        data["status"] = "closed"
+        path.write_text(json.dumps(data))
+        invalid = self.tm.invalid_closed_epics()
+        self.assertIn(epic_id, invalid)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why
- added tests for Epic dataclass conversion, CLI remove commands and invalid status detection
- documented Epic CLI usage in docs and README

## Verification steps
- `./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_683f42dd19dc8333ab96a0cf7cc41fb5