### PR TITLE
[TM_WEB-26] Add GitHub queue management

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-26.json
+++ b/.tasks/TM_WEB/TM_WEB-26.json
@@ -2,15 +2,26 @@
   "id": "TM_WEB-26",
   "title": "Add queue management via GitHub API",
   "description": "Implement queue creation, deletion, and modification through GitHub API. Handle queue file operations and maintain queue-task relationships in repository structure.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting work on queue management via GitHub API",
+      "created_at": 1748976680.2721958
+    },
+    {
+      "id": 2,
+      "text": "Implemented queue create/update/delete functions and tests",
+      "created_at": 1748976975.4175212
+    }
+  ],
   "links": {
     "related": [
       "TM_WEB-22"
     ]
   },
   "created_at": 1748887676.921186,
-  "updated_at": 1748887701.357137,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1748976978.9737144,
+  "started_at": 1748976678.418221,
+  "closed_at": 1748976978.9736736
 }

--- a/react-dashboard/lib/githubTasks.test.ts
+++ b/react-dashboard/lib/githubTasks.test.ts
@@ -1,4 +1,4 @@
-import { fetchTasksFromRepo, createTaskInRepo, updateTaskInRepo } from './githubTasks';
+import { fetchTasksFromRepo, createTaskInRepo, updateTaskInRepo, createQueueInRepo, updateQueueInRepo, deleteQueueInRepo } from './githubTasks';
 import { safeGitHubCall } from './githubClient';
 
 jest.mock('./githubClient', () => ({
@@ -78,5 +78,71 @@ describe('updateTaskInRepo', () => {
   test('throws error for invalid repo string', async () => {
     const task = { id: 'TM_WEB-7', title: 'demo', status: 'todo' as const }
     await expect(updateTaskInRepo('invalidrepo', task)).rejects.toThrow()
+  })
+})
+
+describe('createQueueInRepo', () => {
+  test('calls safeGitHubCall with correct parameters', async () => {
+    const q = { name: 'web', title: 'Web', description: 'desc' }
+    const result = await createQueueInRepo('owner/repo', q, 'tkn')
+    expect(result).toBe(true)
+    const callArgs = (safeGitHubCall as unknown as jest.Mock).mock.calls.pop()
+    expect(typeof callArgs[0]).toBe('function')
+    expect(callArgs[1]).toBe('tkn')
+  })
+
+  test('returns false when safeGitHubCall fails', async () => {
+    ;(safeGitHubCall as unknown as jest.Mock).mockResolvedValueOnce(null)
+    const q = { name: 'a', title: 'b', description: 'c' }
+    const result = await createQueueInRepo('owner/repo', q, 'tkn')
+    expect(result).toBe(false)
+  })
+
+  test('throws error for invalid repo string', async () => {
+    const q = { name: 'x', title: 'y', description: 'z' }
+    await expect(createQueueInRepo('invalidrepo', q)).rejects.toThrow()
+  })
+})
+
+describe('updateQueueInRepo', () => {
+  test('calls safeGitHubCall with correct parameters', async () => {
+    const q = { name: 'web', title: 'New', description: 'new' }
+    const result = await updateQueueInRepo('owner/repo', q, 'tkn')
+    expect(result).toBe(true)
+    const callArgs = (safeGitHubCall as unknown as jest.Mock).mock.calls.pop()
+    expect(typeof callArgs[0]).toBe('function')
+    expect(callArgs[1]).toBe('tkn')
+  })
+
+  test('returns false when safeGitHubCall fails', async () => {
+    ;(safeGitHubCall as unknown as jest.Mock).mockResolvedValueOnce(null)
+    const q = { name: 'web', title: 'x', description: 'y' }
+    const result = await updateQueueInRepo('owner/repo', q, 'tkn')
+    expect(result).toBe(false)
+  })
+
+  test('throws error for invalid repo string', async () => {
+    const q = { name: 'bad', title: 'c', description: 'd' }
+    await expect(updateQueueInRepo('invalidrepo', q)).rejects.toThrow()
+  })
+})
+
+describe('deleteQueueInRepo', () => {
+  test('calls safeGitHubCall with correct parameters', async () => {
+    const result = await deleteQueueInRepo('owner/repo', 'web', 'tkn')
+    expect(result).toBe(true)
+    const callArgs = (safeGitHubCall as unknown as jest.Mock).mock.calls.pop()
+    expect(typeof callArgs[0]).toBe('function')
+    expect(callArgs[1]).toBe('tkn')
+  })
+
+  test('returns false when safeGitHubCall fails', async () => {
+    ;(safeGitHubCall as unknown as jest.Mock).mockResolvedValueOnce(null)
+    const result = await deleteQueueInRepo('owner/repo', 'web', 'tkn')
+    expect(result).toBe(false)
+  })
+
+  test('throws error for invalid repo string', async () => {
+    await expect(deleteQueueInRepo('invalidrepo', 'web')).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## What
- add create, update and delete queue helpers in `githubTasks.ts`
- cover queue GitHub helpers with unit tests
- document progress in TM_WEB-26 task

## Why
- the dashboard needs GitHub API support for queue management

## Verification Steps
- `./run_tests`


------
https://chatgpt.com/codex/tasks/task_e_683f436a46f48333b9ed1fb6de04f6c0