### PR TITLE
[TM_WEB-15] Create React component test plan

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-15.json
+++ b/.tasks/TM_WEB/TM_WEB-15.json
@@ -2,15 +2,27 @@
   "id": "TM_WEB-15",
   "title": "Create comprehensive test plan for React components",
   "description": "Develop a detailed testing strategy for TM_WEB React dashboard including unit tests, integration tests, and component testing. Define testing framework, tools, and coverage requirements.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Starting TM_WEB-15: create test plan",
+      "created_at": 1749018147.3505008
+    },
+    {
+      "id": 2,
+      "text": "Created react test plan and updated README",
+      "created_at": 1749018293.5153525
+    }
+  ],
   "links": {
     "related": [
       "TM_WEB-16"
     ]
   },
+  "epics": [],
   "created_at": 1748556897.361933,
-  "updated_at": 1748556913.12002,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1749018293.5153856,
+  "started_at": 1749018145.0128136,
+  "closed_at": 1749018290.9035583
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This script automatically:
 - Runs React tests (`cd react-dashboard && npm test`)
 - Runs task verification (`./tm verify`)
 - Provides colored output and comprehensive summary
+- For React component guidelines see `docs/react_test_plan.md`
 
 ## Task Manager CLI
 

--- a/docs/react_test_plan.md
+++ b/docs/react_test_plan.md
@@ -1,0 +1,55 @@
+# React Dashboard Test Plan
+
+This document outlines the testing strategy for the TM_WEB React dashboard. It covers unit tests, integration tests, and component testing.
+
+## Goals
+- Verify that all UI components render correctly and handle user interactions.
+- Ensure integration with the task manager API functions properly.
+- Provide confidence during refactoring through high test coverage.
+
+## Testing Framework
+- **Jest** for running the test suites.
+- **React Testing Library** for DOM interactions and component behavior.
+- **msw (Mock Service Worker)** for mocking API responses during integration tests.
+
+## Test Types
+### Unit Tests
+Focus on isolated components and utility functions. Stub external modules and assert rendering and callbacks.
+
+### Integration Tests
+Test multiple components working together, including API hooks. Use `msw` to simulate backend responses.
+
+### Component Snapshot Tests
+Use Jest snapshots sparingly to detect unintentional UI changes. Update snapshots only when visual changes are intentional.
+
+## Coverage Requirements
+- Aim for **80% line coverage** across the `components/`, `hooks/`, and `lib/` directories.
+- Critical components such as the task list and task detail views should approach **100% coverage**.
+
+## Continuous Integration
+All tests run through the `./run_tests` script, which invokes `npm test` inside `react-dashboard/`.
+
+## Directory Structure
+```
+react-dashboard/
+  components/      # UI components
+  hooks/           # React hooks
+  lib/             # Utility modules
+  __tests__/       # Shared test utilities
+```
+
+## Writing New Tests
+1. Place test files alongside the component using `*.test.tsx` or `*.test.ts`.
+2. Import utilities from `@testing-library/react` to render components.
+3. Mock API calls with `msw` handlers defined in `__tests__/mocks`.
+4. Use `npm test -- -u` to update snapshots when needed.
+
+## Running Tests Locally
+```
+cd react-dashboard
+npm install
+npm test
+```
+
+The Jest configuration is in `react-dashboard/jest.config.js` and automatically loads `jest.setup.js` before each test run.
+


### PR DESCRIPTION
## Summary
- add a testing plan for the React dashboard
- link to the new plan from the README

## Testing
- `./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_683fe5bd48248333ab80979983e9a8a0