### PR TITLE
[TM_TUI-12] Update TUI epic display

### DIFF
--- a/.tasks/TM_TUI/TM_TUI-12.json
+++ b/.tasks/TM_TUI/TM_TUI-12.json
@@ -18,6 +18,11 @@
       "id": 3,
       "text": "Fixed cycle detection and button handling",
       "created_at": 1749020930.3652408
+    },
+    {
+      "id": 4,
+      "text": "Fix missing ViewTask handler in TaskDetailScreen",
+      "created_at": 1749022175.0516357
     }
   ],
   "links": {
@@ -29,7 +34,7 @@
     "epic-1"
   ],
   "created_at": 1749018733.3395462,
-  "updated_at": 1749020930.365283,
+  "updated_at": 1749022264.987912,
   "started_at": 1749019136.1328392,
   "closed_at": 1749019358.4131665
 }

--- a/task-manager/task_manager/tui.py
+++ b/task-manager/task_manager/tui.py
@@ -527,6 +527,15 @@ else:
         def on_view_epic(self, message: ViewEpic) -> None:  # pragma: no cover - UI callbacks
             self.app.push_screen(EpicDetailScreen(self.manager, message.epic_id))
 
+        def on_view_task(self, message: ViewTask) -> None:  # pragma: no cover - UI callbacks
+            if (
+                self._handle_manager_operation(
+                    self.manager.task_show, message.task_id
+                )
+                is not None
+            ):
+                self.app.push_screen(TaskDetailScreen(self.manager, message.task_id))
+
     class EpicDetailScreen(BaseScreen):
         def __init__(self, manager: "TaskManager", epic_id: str) -> None:
             super().__init__(manager)


### PR DESCRIPTION
## What
- show epic hierarchy and related tasks in task detail view
- record work on task TM_TUI-12

## Why
- TUI should match CLI improvements by exposing epic descriptions and statuses

## Testing
- `./run_tests`

------
https://chatgpt.com/codex/tasks/task_e_683fe9c6ece0833383b73a11db91710c