### PR TITLE
[TM_WEB-33] Display epic information in task page

### DIFF
--- a/.epics/epic-1.json
+++ b/.epics/epic-1.json
@@ -2,7 +2,7 @@
   "id": "epic-1",
   "title": "Improve task information display",
   "description": "Enhance task show command to display comprehensive epic information including parent epic details and all related tasks and epics within the same epic with their descriptions and statuses",
-  "status": "open",
+  "status": "closed",
   "child_tasks": [
     "TM-15",
     "TM_TUI-12",
@@ -15,5 +15,5 @@
   ],
   "parent_epic": null,
   "created_at": 1749018715.335389,
-  "updated_at": 1749020659.2710452
+  "updated_at": 1749118419.4204023
 }

--- a/.tasks/TM_WEB/TM_WEB-33.json
+++ b/.tasks/TM_WEB/TM_WEB-33.json
@@ -2,8 +2,19 @@
   "id": "TM_WEB-33",
   "title": "Update Web dashboard task view with enhanced epic information",
   "description": "Adapt React web dashboard to display enhanced epic information in task views. Show epic hierarchy and related tasks/epics with descriptions and statuses. Ensure consistent display with CLI improvements.",
-  "status": "todo",
-  "comments": [],
+  "status": "done",
+  "comments": [
+    {
+      "id": 1,
+      "text": "Start implementing Task epic info UI",
+      "created_at": 1749117660.6808314
+    },
+    {
+      "id": 2,
+      "text": "Implemented Task epic info component and page updates",
+      "created_at": 1749118425.3974988
+    }
+  ],
   "links": {
     "related": [
       "TM-15"
@@ -13,7 +24,7 @@
     "epic-1"
   ],
   "created_at": 1749018737.961942,
-  "updated_at": 1749018764.659486,
-  "started_at": null,
-  "closed_at": null
+  "updated_at": 1749118425.397531,
+  "started_at": 1749117657.5927126,
+  "closed_at": 1749118419.4184241
 }

--- a/react-dashboard/components/TaskEpicInfo.test.tsx
+++ b/react-dashboard/components/TaskEpicInfo.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import TaskEpicInfo from './TaskEpicInfo'
+import { Epic, Task } from '../types'
+
+test('renders parent epic details with related tasks and child epics', () => {
+  const epics: Epic[] = [
+    { id: 'epic-1', title: 'E1', status: 'open', description: 'desc', child_tasks: ['TM-1', 'TM-2'], child_epics: ['epic-2'], parent_epic: null },
+    { id: 'epic-2', title: 'E2', status: 'open', child_tasks: [], child_epics: [], parent_epic: 'epic-1' }
+  ]
+  const tasks: Task[] = [
+    { id: 'TM-1', title: 'Task1', status: 'todo' },
+    { id: 'TM-2', title: 'Task2', status: 'done' }
+  ]
+  render(<TaskEpicInfo taskId="TM-1" epics={epics} tasks={tasks} />)
+  expect(screen.getByText('epic-1')).toBeInTheDocument()
+  expect(screen.getByText(/Task2/)).toBeInTheDocument()
+  expect(screen.getByText('epic-2')).toBeInTheDocument()
+})

--- a/react-dashboard/components/TaskEpicInfo.tsx
+++ b/react-dashboard/components/TaskEpicInfo.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import Link from 'next/link'
+import { Epic, Task } from '../types'
+
+interface TaskEpicInfoProps {
+  taskId: string
+  epics: Epic[]
+  tasks: Task[]
+}
+
+export default function TaskEpicInfo({ taskId, epics, tasks }: TaskEpicInfoProps) {
+  const parents = epics.filter(e => e.child_tasks.includes(taskId))
+  if (parents.length === 0) return null
+
+  const findTask = (tid: string): Task | undefined => tasks.find(t => t.id === tid)
+  const findEpic = (eid: string): Epic | undefined => epics.find(e => e.id === eid)
+
+  return (
+    <div>
+      <h2>Epics</h2>
+      {parents.map(epic => {
+        const otherTasks = epic.child_tasks.filter(tid => tid !== taskId)
+        return (
+          <div key={epic.id} style={{ marginBottom: '1rem' }}>
+            <p>
+              <Link href={`/epic/${epic.id}`}>{epic.id}</Link> - {epic.title} [{epic.status}]
+            </p>
+            {epic.description && <p>{epic.description}</p>}
+            {otherTasks.length > 0 && (
+              <>
+                <h3>Tasks</h3>
+                <ul>
+                  {otherTasks.map(tid => {
+                    const t = findTask(tid)
+                    return (
+                      <li key={tid}>
+                        {t ? <Link href={`/task/${tid}`}>{tid}</Link> : tid}
+                        {t ? `: ${t.title} (${t.status})` : ' (missing)'}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </>
+            )}
+            {epic.child_epics.length > 0 && (
+              <>
+                <h3>Child Epics</h3>
+                <ul>
+                  {epic.child_epics.map(eid => {
+                    const child = findEpic(eid)
+                    return (
+                      <li key={eid}>
+                        {child ? <Link href={`/epic/${eid}`}>{eid}</Link> : eid}
+                        {child ? `: ${child.title} (${child.status})` : ' (missing)'}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/react-dashboard/pages/task/[id].tsx
+++ b/react-dashboard/pages/task/[id].tsx
@@ -5,6 +5,9 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import { useTaskContext } from '../../context/TaskContext'
 import { useAuth } from '../../context/AuthContext'
 import Navigation from '../../components/Navigation'
+import useEpics from '../../hooks/useEpics'
+import useTasks from '../../hooks/useTasks'
+import TaskEpicInfo from '../../components/TaskEpicInfo'
 import styles from '../Page.module.css'
 import { Task } from '../../types'
 
@@ -56,6 +59,8 @@ export default function TaskPage({ task }: TaskPageProps) {
   const [success, setSuccess] = useState<boolean>(false)
   const { setTasks } = useTaskContext()
   const { csrfToken, token } = useAuth()
+  const epics = useEpics()
+  const tasksList = useTasks()
 
   const save = async (): Promise<void> => {
     setSaving(true)
@@ -126,6 +131,7 @@ export default function TaskPage({ task }: TaskPageProps) {
       </button>
       <h2>Description</h2>
       <p>{task.description}</p>
+      <TaskEpicInfo taskId={task.id} epics={epics} tasks={tasksList} />
       <h2>Comments</h2>
       <ul>
         {(task.comments || []).map((c) => (


### PR DESCRIPTION
## What changed and why
- added `TaskEpicInfo` component to show parent epic details with related tasks and child epics
- updated task page to load epics/tasks via hooks and render the new component
- added component tests
- closed TM_WEB-33 in tasks and epic-1 automatically closed

## Verification steps
- `./run_tests` *(fails to complete due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684169f9b074833389543995ca431470