### PR TITLE
[TM_WEB-43] Build individual task and epic detail pages

### DIFF
--- a/.tasks/TM_WEB/TM_WEB-43.json
+++ b/.tasks/TM_WEB/TM_WEB-43.json
@@ -13,6 +13,11 @@
       "id": 2,
       "text": "Epic details page enhanced",
       "created_at": 1749155466.9341242
+    },
+    {
+      "id": 3,
+      "text": "Fixing unprotected access to epic child lists",
+      "created_at": 1749195874.7985344
     }
   ],
   "links": {},
@@ -20,7 +25,7 @@
     "epic-3"
   ],
   "created_at": 1749120302.774859,
-  "updated_at": 1749155466.9341795,
+  "updated_at": 1749196054.7343225,
   "started_at": 1749154791.2662838,
   "closed_at": 1749155462.378429
 }

--- a/react-dashboard/pages/epic/[id].tsx
+++ b/react-dashboard/pages/epic/[id].tsx
@@ -48,11 +48,11 @@ export default function EpicPage() {
           Parent Epic: <Link href={`/epic/${parent.id}`}>{parent.id}</Link> - {parent.title}
         </p>
       )}
-      {current.child_tasks.length > 0 && (
+      {current.child_tasks?.length > 0 && (
         <>
           <h2>Tasks</h2>
           <ul>
-            {current.child_tasks.map(tid => {
+            {current.child_tasks?.map(tid => {
               const t = tasks.find(t => t.id === tid)
               return (
                 <li key={tid}>
@@ -64,11 +64,11 @@ export default function EpicPage() {
           </ul>
         </>
       )}
-      {current.child_epics.length > 0 && (
+      {current.child_epics?.length > 0 && (
         <>
           <h2>Child Epics</h2>
           <ul>
-            {current.child_epics.map(eid => {
+            {current.child_epics?.map(eid => {
               const child = epics.find(e => e.id === eid)
               return (
                 <li key={eid}>


### PR DESCRIPTION
## Summary
- display epic descriptions, parent, and child lists on detail page
- record work on TM_WEB-43 task

## Testing
- `./run_tests` *(fails: KeyboardInterrupt during mypy and React tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb5439c083338981e15503adb06c